### PR TITLE
updating Docker dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     container_name: kafka
 
   valhalla:
-    image: valhalla/docker:1.2.4
+    image: valhalla/docker:ppa-1.2.5
     ports:
       - "8002:8002"
     volumes:


### PR DESCRIPTION
I've been trying to debug https://github.com/opentraffic/reporter/issues/90 locally.

When I try to start the current docker-compose rig, I get the following error

```sh
$ GOOGLE_MAPS=xxx MAPZEN_API=mapzenxxx VALHALLA_DOCKER_DATAPATH=./planet_2017_07_08-00_34_29 docker-compose up
Pulling valhalla (valhalla/docker:1.2.4)...
ERROR: manifest for valhalla/docker:1.2.4 not found
```

After updating the Valhalla dependency locally, I'm able to proceed.